### PR TITLE
Fix tex styling keywords in the title.

### DIFF
--- a/NeurIPSCDT-2019.bib
+++ b/NeurIPSCDT-2019.bib
@@ -81,7 +81,7 @@
 
 @inproceedings{okelly20,
   author    = {Matthew O'Kelly and   Hongrui Zheng and Dhruv Karthik and Rahul Mangharam},
-  title     = {textsc{F1TENTH}: An Open-source Evaluation Environment for Continuous Control and Reinforcement Learning},
+  title     = {F1TENTH: An Open-source Evaluation Environment for Continuous Control and Reinforcement Learning},
   booktitle = {Proceedings of the NeurIPS 2019 Competition and Demonstration Track},
   pages     = {77--89},
   year      = {2020},

--- a/_posts/2020-08-19-o-kelly20a.md
+++ b/_posts/2020-08-19-o-kelly20a.md
@@ -1,5 +1,5 @@
 ---
-title: 'textscF1TENTH: An Open-source Evaluation Environment for Continuous Control
+title: 'F1TENTH: An Open-source Evaluation Environment for Continuous Control
   and Reinforcement Learning'
 booktitle: Proceedings of the NeurIPS 2019 Competition and Demonstration Track
 year: '2020'
@@ -17,7 +17,7 @@ publisher: PMLR
 issn: 2640-3498
 id: o-kelly20a
 month: 0
-tex_title: 'textsc{F1TENTH}: An Open-source Evaluation Environment for Continuous
+tex_title: 'F1TENTH: An Open-source Evaluation Environment for Continuous
   Control and Reinforcement Learning'
 firstpage: 77
 lastpage: 89


### PR DESCRIPTION
The BibTeX for our paper includes the tex keyword textsc{} in the title. This PR removes the keyword.